### PR TITLE
Feature inyect stacktrace as attribute

### DIFF
--- a/examples/example-1.php
+++ b/examples/example-1.php
@@ -13,6 +13,7 @@ function recursiveFunction(Telephponic $tracer, int $number = 10): int
 {
     if ($number === 0) {
         $tracer->start('recursiveFunction', ['number' => $number]);
+        $tracer->addException(new RuntimeException('recursive exception'));
         $tracer->end();
 
         return 0;
@@ -31,6 +32,7 @@ $builder->enableBatchMode()
         ->withProbabilitySampler(1)
         ->withRedisIntegration(true, true, true, true, true, true, true)
         ->withCurlIntegration(true, true, true)
+        ->enableAddTraceAsAttribute()
         ->withPDOIntegration()
 ;
 

--- a/examples/example-1.php
+++ b/examples/example-1.php
@@ -3,10 +3,23 @@
 declare(strict_types=1);
 
 use GR\Telephponic\Trace\Builder\Builder;
+use GR\Telephponic\Trace\Telephponic;
 
 error_reporting(E_ALL & ~E_NOTICE);
 
 include_once __DIR__ . '/../vendor/autoload.php';
+
+function recursiveFunction(Telephponic $tracer, int $number = 10): int
+{
+    if ($number === 0) {
+        $tracer->start('recursiveFunction', ['number' => $number]);
+        $tracer->end();
+
+        return 0;
+    }
+
+    return recursiveFunction($tracer, $number - 1);
+}
 
 // $url = 'http://zipkin:9411/api/v2/spans';
 $url = 'http://jaeger:4317';
@@ -21,6 +34,7 @@ $builder->enableBatchMode()
         ->withPDOIntegration()
 ;
 
+global $tracer;
 $tracer = $builder->build();
 
 $tracer->addWatcherToFunction('sleep', static function (int $time): array {
@@ -32,12 +46,18 @@ $tracer->addWatcherToFunction('sleep', static function (int $time): array {
 });
 
 $tracer->start('search-engine');
-$tracer->addEvent('search-engine-started', ['search-engine' => 'started']);
-sleep(1);
-$tracer->start('search-engine-child');
-sleep(2);
-$tracer->addException(new RuntimeException('test exception'));
-$tracer->end();
+{
+    $tracer->addEvent('search-engine-started', ['search-engine' => 'started']);
+    sleep(1);
+    $tracer->start('search-engine-child');
+    {
+        sleep(2);
+        $tracer->addException(new RuntimeException('test exception'));
+    }
+    $tracer->end();
+
+    recursiveFunction($tracer, 12);
+}
 $tracer->end();
 
 $tracer->shutdown();

--- a/src/Trace/Builder/Builder.php
+++ b/src/Trace/Builder/Builder.php
@@ -414,10 +414,10 @@ class Builder
 
     public function enableAddTraceAsAttribute(): self
     {
-        return $this->withPlaintTextStacktraceProvider();
+        return $this->withPlainTextStacktraceProvider();
     }
 
-    public function withPlaintTextStacktraceProvider(): self
+    public function withPlainTextStacktraceProvider(): self
     {
         return $this->withStacktraceProvider(new PlainTextStacktraceProvider());
     }

--- a/src/Trace/Builder/Builder.php
+++ b/src/Trace/Builder/Builder.php
@@ -11,6 +11,8 @@ use GR\Telephponic\Trace\Integration\Integration;
 use GR\Telephponic\Trace\Integration\Memcached;
 use GR\Telephponic\Trace\Integration\PDO;
 use GR\Telephponic\Trace\Integration\Redis;
+use GR\Telephponic\Trace\Stacktrace\PlainTextStacktraceProvider;
+use GR\Telephponic\Trace\Stacktrace\StacktraceProvider;
 use GR\Telephponic\Trace\Telephponic;
 use InvalidArgumentException;
 use OpenTelemetry\API\Common\Signal\Signals;
@@ -50,6 +52,7 @@ class Builder
     private bool $batchMode = false;
     private array $defaultAttributes = [];
     private $registerShutdown = true;
+    private ?StacktraceProvider $stacktraceProvider = null;
     private array $integrations = [];
 
     public function __construct(
@@ -230,6 +233,7 @@ class Builder
             $tracer,
             $this->defaultAttributes,
             $this->registerShutdown,
+            $this->stacktraceProvider,
             ...$this->integrations,
         );
     }
@@ -406,5 +410,29 @@ class Builder
                 $tracePdoStatementBindParam,
             )
         );
+    }
+
+    public function enableAddTraceAsAttribute(): self
+    {
+        return $this->withPlaintTextStacktraceProvider();
+    }
+
+    public function withPlaintTextStacktraceProvider(): self
+    {
+        return $this->withStacktraceProvider(new PlainTextStacktraceProvider());
+    }
+
+    public function withStacktraceProvider(StacktraceProvider $stacktraceProvider): self
+    {
+        $this->stacktraceProvider = $stacktraceProvider;
+
+        return $this;
+    }
+
+    public function disableAddTraceAsAttribute(): self
+    {
+        $this->stacktraceProvider = null;
+
+        return $this;
     }
 }

--- a/src/Trace/Stacktrace/PlainTextStacktraceProvider.php
+++ b/src/Trace/Stacktrace/PlainTextStacktraceProvider.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GR\Telephponic\Trace\Stacktrace;
+
+class PlainTextStacktraceProvider implements StacktraceProvider
+{
+
+    public function getStacktraces(): string
+    {
+        $stacktraces = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+        // clean index 0-1
+        // 0: PlainTextStacktraceProvider->getStacktraces()
+        // 1: Telephponic->end()
+        unset($stacktraces[0], $stacktraces[1]);
+        $stacktraces = array_values($stacktraces);
+        $maxIndex = count($stacktraces) - 1;
+        $numOfSpaces = (int)log10($maxIndex) + 1;
+
+        $output = '';
+
+        // if trace is created using hooks or autointrumentation, the first stacktrace is the hook itself, remove it.
+        if (str_contains(($stacktraces[0]['function'] ?? ''), '{closure}')) {
+            unset($stacktraces[0]);
+            $stacktraces = array_values($stacktraces);
+        }
+
+        foreach ($stacktraces as $index => $stacktrace) {
+            $output .= sprintf(
+                "#%0{$numOfSpaces}s %s:%d %s%s%s()\n",
+                $index,
+                $stacktrace['file'] ?? 'main',
+                $stacktrace['line'] ?? 0,
+                $stacktrace['class'] ?? '',
+                $stacktrace['type'] ?? '',
+                $stacktrace['function'] ?? 'unknown'
+            );
+        }
+
+        return trim($output);
+    }
+}

--- a/src/Trace/Stacktrace/StacktraceProvider.php
+++ b/src/Trace/Stacktrace/StacktraceProvider.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GR\Telephponic\Trace\Stacktrace;
+
+interface StacktraceProvider
+{
+    public function getStacktraces(): mixed;
+}

--- a/src/Trace/Telephponic.php
+++ b/src/Trace/Telephponic.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GR\Telephponic\Trace;
 
 use GR\Telephponic\Trace\Integration\Integration;
+use GR\Telephponic\Trace\Stacktrace\StacktraceProvider;
 use OpenTelemetry\API\Trace\Span;
 use OpenTelemetry\API\Trace\SpanInterface;
 use OpenTelemetry\API\Trace\StatusCode;
@@ -26,6 +27,7 @@ class Telephponic
         private readonly TracerProviderInterface $tracerProvider,
         private readonly array $defaultAttributes = [],
         private readonly bool $registerShutdown = true,
+        readonly ?StacktraceProvider $stacktraceProvider = null,
         Integration ...$integrations
     ) {
         $this->tracer = $this->tracerProvider->getTracer('telephponic-tracer');
@@ -128,7 +130,15 @@ class Telephponic
     public function end(): void
     {
         $scope = $this->getScope();
-        $this->getSpan()->end();
+        $span = $this->getSpan();
+        if (null !== $this->stacktraceProvider) {
+            $stacktrace = $this->stacktraceProvider->getStacktraces();
+            if (!empty($stacktrace)) {
+                $span->setAttribute('span.stacktrace', $stacktrace);
+            }
+        }
+
+        $span->end();
         $scope?->detach();
     }
 

--- a/src/Trace/Telephponic.php
+++ b/src/Trace/Telephponic.php
@@ -27,7 +27,7 @@ class Telephponic
         private readonly TracerProviderInterface $tracerProvider,
         private readonly array $defaultAttributes = [],
         private readonly bool $registerShutdown = true,
-        readonly ?StacktraceProvider $stacktraceProvider = null,
+        private readonly ?StacktraceProvider $stacktraceProvider = null,
         Integration ...$integrations
     ) {
         $this->tracer = $this->tracerProvider->getTracer('telephponic-tracer');


### PR DESCRIPTION
Now you can pass an instance of StacktraceProvider to Telephponic
constructor or enable plain text stacktracing using
Builder::enableAddStactTraceAsAttribute() method.
    
This will add a new attribute called `span.stacktrace` with the debug
stacktrace output, that will help developers to debug better any
suspicious trace found in trace panels.
    
Be careful when using this option with Google's Trace app, because it
has a native limit of 256 chars as max length for attribute values.