### PR TITLE
feat(SpanProcessor): Custom span processor

### DIFF
--- a/src/Trace/Builder/Builder.php
+++ b/src/Trace/Builder/Builder.php
@@ -37,6 +37,7 @@ use OpenTelemetry\SDK\Trace\SpanExporter\InMemoryExporter;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 use OpenTelemetry\SDK\Trace\SpanProcessor\BatchSpanProcessor;
 use OpenTelemetry\SDK\Trace\SpanProcessor\SimpleSpanProcessor;
+use OpenTelemetry\SDK\Trace\SpanProcessorInterface;
 use OpenTelemetry\SDK\Trace\TracerProvider;
 use OpenTelemetry\SemConv\ResourceAttributes;
 use RuntimeException;
@@ -49,6 +50,7 @@ class Builder
     private ?ClockInterface $clock = null;
     private ?SpanExporterInterface $exporter = null;
     private bool $batchMode = false;
+    private array $additionalSpanProcessors = [];
     private array $defaultAttributes = [];
     private bool $registerShutdown = true;
     private ?StacktraceProvider $stacktraceProvider = null;
@@ -210,9 +212,12 @@ class Builder
         }
 
         $tracer = new TracerProvider(
-            $this->batchMode
-                ? $this->createBatchSpanProcessor()
-                : $this->createSimpleSpanProcessor(),
+            [
+                $this->batchMode
+                    ? $this->createBatchSpanProcessor()
+                    : $this->createSimpleSpanProcessor(),
+                ...$this->additionalSpanProcessors,
+            ],
             $this->sampler,
             $this->resourceInfo,
         );
@@ -315,6 +320,13 @@ class Builder
     public function withIntegration(Integration $integration): self
     {
         $this->integrations[] = $integration;
+
+        return $this;
+    }
+
+    public function withSpanProcessor(SpanProcessorInterface $processor): self
+    {
+        $this->additionalSpanProcessors[] = $processor;
 
         return $this;
     }

--- a/src/Trace/Telephponic.php
+++ b/src/Trace/Telephponic.php
@@ -43,16 +43,20 @@ class Telephponic
         $this->addIntegrations(...$integrations);
     }
 
-    public function start(string $name, array $attributes = []): void
+    public function start(string $name, array $attributes = [], ?int $startTimestampNanos = null): void
     {
-        $span = $this->createSpan($name);
+        $span = $this->createSpan($name, $startTimestampNanos);
         $span->setAttributes($this->defaultAttributes + $attributes);
         $this->saveSpan($span);
     }
 
-    private function createSpan(string $name): SpanInterface
+    private function createSpan(string $name, ?int $startTimestampNanos = null): SpanInterface
     {
-        return $this->tracer->spanBuilder($name)->startSpan();
+        $builder = $this->tracer->spanBuilder($name);
+        if ($startTimestampNanos !== null) {
+            $builder->setStartTimestamp($startTimestampNanos);
+        }
+        return $builder->startSpan();
     }
 
     private function saveSpan(SpanInterface $span): void

--- a/test/Trace/BuilderTest.php
+++ b/test/Trace/BuilderTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GR\Telephponic\Test\Trace;
+
+use GR\Telephponic\Trace\Builder\Builder;
+use OpenTelemetry\SemConv\ResourceAttributes;
+use PHPUnit\Framework\TestCase;
+
+class BuilderTest extends TestCase
+{
+    // -------------------------------------------------------------------------
+    // withSpanProcessor
+    // -------------------------------------------------------------------------
+
+    public function test_withSpanProcessor_processor_receives_onStart_for_every_span(): void
+    {
+        $spy = new SpanProcessorSpy();
+
+        $telephponic = Builder::get('test', 'ns', 'test')
+            ->withInMemoryExporter()
+            ->disableShutDown()
+            ->withSpanProcessor($spy)
+            ->build();
+
+        // Constructor creates one root span; one call expected so far.
+        $this->assertCount(1, $spy->starts);
+
+        $telephponic->start('child-span');
+
+        $this->assertCount(2, $spy->starts);
+        $this->assertSame('child-span', $spy->starts[1]['name']);
+    }
+
+    public function test_withSpanProcessor_multiple_processors_all_called(): void
+    {
+        $spy1 = new SpanProcessorSpy();
+        $spy2 = new SpanProcessorSpy();
+
+        Builder::get('test', 'ns', 'test')
+            ->withInMemoryExporter()
+            ->disableShutDown()
+            ->withSpanProcessor($spy1)
+            ->withSpanProcessor($spy2)
+            ->build();
+
+        $this->assertCount(1, $spy1->starts);
+        $this->assertCount(1, $spy2->starts);
+    }
+
+    public function test_withDefaultResource_uses_deployment_environment_name_constant(): void
+    {
+        $this->assertSame('deployment.environment', ResourceAttributes::DEPLOYMENT_ENVIRONMENT);
+
+        // Building also exercises withDefaultResource() internally — any use of the
+        // old constant would throw "Undefined constant" here.
+        $telephponic = Builder::get('app', 'ns', 'production')
+            ->withInMemoryExporter()
+            ->disableShutDown()
+            ->build();
+
+        $this->assertNotNull($telephponic);
+    }
+}

--- a/test/Trace/SpanProcessorBehaviorTest.php
+++ b/test/Trace/SpanProcessorBehaviorTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GR\Telephponic\Test\Trace;
+
+use GR\Telephponic\Trace\Builder\Builder;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verifies that span processors receive onStart and onEnd in the right order
+ * and with the right data as spans are created and ended via Telephponic.
+ */
+class SpanProcessorBehaviorTest extends TestCase
+{
+    private function builder(): Builder
+    {
+        return Builder::get('test', 'ns', 'test')
+            ->withInMemoryExporter()
+            ->disableShutDown();
+    }
+
+    // -------------------------------------------------------------------------
+    // onStart
+    // -------------------------------------------------------------------------
+
+    public function test_onStart_is_called_when_span_starts(): void
+    {
+        $spy = new SpanProcessorSpy();
+
+        $telephponic = $this->builder()->withSpanProcessor($spy)->build();
+        // Constructor already started the root span.
+        $this->assertCount(1, $spy->starts);
+
+        $telephponic->start('my-span');
+        $this->assertCount(2, $spy->starts);
+        $this->assertSame('my-span', $spy->starts[1]['name']);
+    }
+
+    public function test_onStart_is_called_on_all_processors(): void
+    {
+        $spy1 = new SpanProcessorSpy();
+        $spy2 = new SpanProcessorSpy();
+
+        $telephponic = $this->builder()
+            ->withSpanProcessor($spy1)
+            ->withSpanProcessor($spy2)
+            ->build();
+
+        $telephponic->start('span');
+
+        $this->assertCount(2, $spy1->starts);
+        $this->assertCount(2, $spy2->starts);
+    }
+
+    // -------------------------------------------------------------------------
+    // onEnd
+    // -------------------------------------------------------------------------
+
+    public function test_onEnd_is_called_when_span_ends(): void
+    {
+        $spy = new SpanProcessorSpy();
+
+        $telephponic = $this->builder()->withSpanProcessor($spy)->build();
+        $telephponic->start('child');
+        $telephponic->end();
+
+        $this->assertCount(1, $spy->ends);
+        $this->assertSame('child', $spy->ends[0]['name']);
+    }
+
+    public function test_onEnd_is_called_on_all_processors(): void
+    {
+        $spy1 = new SpanProcessorSpy();
+        $spy2 = new SpanProcessorSpy();
+
+        $telephponic = $this->builder()
+            ->withSpanProcessor($spy1)
+            ->withSpanProcessor($spy2)
+            ->build();
+
+        $telephponic->start('span');
+        $telephponic->end();
+
+        $this->assertCount(1, $spy1->ends);
+        $this->assertCount(1, $spy2->ends);
+    }
+
+    // -------------------------------------------------------------------------
+    // onStart before onEnd
+    // -------------------------------------------------------------------------
+
+    public function test_onStart_is_called_before_onEnd(): void
+    {
+        $order = [];
+
+        $orderSpy = new class($order) implements \OpenTelemetry\SDK\Trace\SpanProcessorInterface {
+            public function __construct(private array &$order) {}
+
+            public function onStart(\OpenTelemetry\SDK\Trace\ReadWriteSpanInterface $span, \OpenTelemetry\Context\ContextInterface $parentContext): void
+            {
+                $this->order[] = 'start:' . $span->getName();
+            }
+
+            public function onEnd(\OpenTelemetry\SDK\Trace\ReadableSpanInterface $span): void
+            {
+                $this->order[] = 'end:' . $span->getName();
+            }
+
+            public function shutdown(?\OpenTelemetry\SDK\Common\Future\CancellationInterface $c = null): bool { return true; }
+            public function forceFlush(?\OpenTelemetry\SDK\Common\Future\CancellationInterface $c = null): bool { return true; }
+        };
+
+        $telephponic = $this->builder()->withSpanProcessor($orderSpy)->build();
+        $telephponic->start('op');
+        $telephponic->end();
+
+        $rootName = $_SERVER['REQUEST_URI'] ?? $_SERVER['argv'][0] ?? 'unknown';
+        $this->assertSame(['start:' . $rootName, 'start:op', 'end:op'], $order);
+    }
+
+    // -------------------------------------------------------------------------
+    // endNanos > startNanos
+    // -------------------------------------------------------------------------
+
+    public function test_end_epoch_nanos_is_after_start_epoch_nanos(): void
+    {
+        $spy = new SpanProcessorSpy();
+
+        $telephponic = $this->builder()->withSpanProcessor($spy)->build();
+        $telephponic->start('timed');
+        $telephponic->end();
+
+        $startNanos = $spy->starts[1]['startNanos'];
+        $endNanos   = $spy->ends[0]['endNanos'];
+
+        $this->assertGreaterThan($startNanos, $endNanos);
+    }
+}

--- a/test/Trace/SpanProcessorSpy.php
+++ b/test/Trace/SpanProcessorSpy.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GR\Telephponic\Test\Trace;
+
+use OpenTelemetry\Context\ContextInterface;
+use OpenTelemetry\SDK\Common\Future\CancellationInterface;
+use OpenTelemetry\SDK\Trace\ReadableSpanInterface;
+use OpenTelemetry\SDK\Trace\ReadWriteSpanInterface;
+use OpenTelemetry\SDK\Trace\SpanProcessorInterface;
+
+final class SpanProcessorSpy implements SpanProcessorInterface
+{
+    /** @var array<array{name: string, startNanos: int}> */
+    public array $starts = [];
+
+    public function onStart(ReadWriteSpanInterface $span, ContextInterface $parentContext): void
+    {
+        $this->starts[] = [
+            'name'       => $span->getName(),
+            'startNanos' => $span->toSpanData()->getStartEpochNanos(),
+        ];
+    }
+
+    public function onEnd(ReadableSpanInterface $span): void
+    {
+    }
+
+    public function shutdown(?CancellationInterface $cancellation = null): bool
+    {
+        return true;
+    }
+
+    public function forceFlush(?CancellationInterface $cancellation = null): bool
+    {
+        return true;
+    }
+}

--- a/test/Trace/SpanProcessorSpy.php
+++ b/test/Trace/SpanProcessorSpy.php
@@ -15,6 +15,9 @@ final class SpanProcessorSpy implements SpanProcessorInterface
     /** @var array<array{name: string, startNanos: int}> */
     public array $starts = [];
 
+    /** @var array<array{name: string, endNanos: int}> */
+    public array $ends = [];
+
     public function onStart(ReadWriteSpanInterface $span, ContextInterface $parentContext): void
     {
         $this->starts[] = [
@@ -25,6 +28,10 @@ final class SpanProcessorSpy implements SpanProcessorInterface
 
     public function onEnd(ReadableSpanInterface $span): void
     {
+        $this->ends[] = [
+            'name'     => $span->getName(),
+            'endNanos' => $span->toSpanData()->getEndEpochNanos(),
+        ];
     }
 
     public function shutdown(?CancellationInterface $cancellation = null): bool

--- a/test/Trace/TelephponicTest.php
+++ b/test/Trace/TelephponicTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GR\Telephponic\Test\Trace;
+
+use GR\Telephponic\Trace\Builder\Builder;
+use PHPUnit\Framework\TestCase;
+
+class TelephponicTest extends TestCase
+{
+    // -------------------------------------------------------------------------
+    // start() with startTimestampNanos
+    // -------------------------------------------------------------------------
+
+    public function test_start_without_timestamp_uses_current_time(): void
+    {
+        $spy = new SpanProcessorSpy();
+        $before = (int) (microtime(true) * 1e9);
+
+        Builder::get('test', 'ns', 'test')
+            ->withInMemoryExporter()
+            ->disableShutDown()
+            ->withSpanProcessor($spy)
+            ->build(); // constructor calls start() for root span
+
+        $after = (int) (microtime(true) * 1e9);
+
+        $rootStart = $spy->starts[0]['startNanos'];
+        $this->assertGreaterThanOrEqual($before, $rootStart);
+        $this->assertLessThanOrEqual($after, $rootStart);
+    }
+
+    public function test_start_with_timestamp_overrides_span_start_time(): void
+    {
+        $spy = new SpanProcessorSpy();
+
+        $telephponic = Builder::get('test', 'ns', 'test')
+            ->withInMemoryExporter()
+            ->disableShutDown()
+            ->withSpanProcessor($spy)
+            ->build();
+
+        $expectedNanos = 1_000_000_000; // 1970-01-01T00:00:01Z
+        $telephponic->start('timed-span', [], $expectedNanos);
+
+        $timedStart = $spy->starts[1]['startNanos'];
+        $this->assertSame($expectedNanos, $timedStart);
+    }
+
+    public function test_start_with_null_timestamp_uses_current_time(): void
+    {
+        $spy = new SpanProcessorSpy();
+
+        $telephponic = Builder::get('test', 'ns', 'test')
+            ->withInMemoryExporter()
+            ->disableShutDown()
+            ->withSpanProcessor($spy)
+            ->build();
+
+        $before = (int) (microtime(true) * 1e9);
+        $telephponic->start('span', [], null);
+        $after = (int) (microtime(true) * 1e9);
+
+        $spanStart = $spy->starts[1]['startNanos'];
+        $this->assertGreaterThanOrEqual($before, $spanStart);
+        $this->assertLessThanOrEqual($after, $spanStart);
+    }
+}


### PR DESCRIPTION
En pikaso se usaba invade para aplicarlo, pero con el cambio de versión ha pasado a readonly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive tracing API and test-only changes; export path still uses the same primary processor, with low impact on runtime behavior unless misused timestamps are passed.
> 
> **Overview**
> Adds a **public builder hook** to register custom OpenTelemetry `SpanProcessor` instances alongside the default batch/simple exporter processor, so apps can observe spans without mutating readonly SDK internals.
> 
> `TracerProvider` is now wired with a **processor list** (export processor first, then any extras from `withSpanProcessor`). `Telephponic::start()` accepts an optional **start time in epoch nanoseconds** so span start times can be set explicitly when needed.
> 
> New PHPUnit coverage verifies processors get `onStart`/`onEnd` (including multiple processors and ordering) and that custom vs default start timestamps behave correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1df10366904ee2d34995b166b7c8e2784b6151c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->